### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,4 +1,6 @@
 name: Build and Release
+permissions:
+  contents: read
 on: [push]
 
 jobs:
@@ -116,6 +118,8 @@ jobs:
   release:
     needs: package-addon
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       STATUS: ${{ !endsWith(github.ref, 'master') && 'alpha' || '' }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/GoodPie/modular_tree/security/code-scanning/10](https://github.com/GoodPie/modular_tree/security/code-scanning/10)

In general, the fix is to declare a `permissions` block in the workflow so jobs do not implicitly inherit the repository default `GITHUB_TOKEN` permissions. We should define least-privilege defaults at the workflow root (applies to all jobs), and then override them only for jobs that need broader permissions.

For this specific file, the safest, non‑functional‑changing approach is:
- Add a workflow‑level `permissions` block after `name` (line 1) that sets `contents: read` (and optionally other read-only scopes if needed). This constrains all jobs by default.
- Add a job‑level `permissions` block for the `release` job because it uses `softprops/action-gh-release@v2` to update/create GitHub releases, which needs to write to repository contents/releases. The minimal sensible permission is `contents: write` for that job alone.
- The other jobs (`lint`, `test`, `build-wheels`, `test-python`, `package-addon`) use checkout, artifacts, Python tooling, etc., but do not modify repo contents via the API, so the root `contents: read` is sufficient and should not be overridden.

Concretely:
- In `.github/workflows/CD.yml`, insert:

```yaml
permissions:
  contents: read
```

on new line 2, shifting the rest down.
- Inside the `release` job definition (around existing line 116), add:

```yaml
    permissions:
      contents: write
```

directly under `runs-on: ubuntu-latest` (or after `needs:` and `runs-on:`), to scope elevated permissions to this job only.

No additional methods, imports, or external dependencies are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
